### PR TITLE
UE naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog for UE_tools repository
 
+## 0.0.2 ##
+CodeGeneratorFromPath.py
+* Remove all '_' in outputted UE struct type name
+* Add `is_valid_group_name()` before assigning `types_cpp[group_name]` to `info[~Types, ~SetFromROS2, SetROS2]`
+* `templates/Action.h, Msg.h, Srv.h` No underscore in UE struct name
+* `get_var_names()` -> `get_ue_var_names`() returns a dict {(type, size):var_name}
+* `convert_to_cpp_type()` -> `convert_to_ue_type()`: add TArray output
+* Add `get_type_default_value_str()` to auto fill-in default value if possible
+
 ## 0.0.1 ##
-------------------------
 * Add CHANGELOG
 * Update maintainers

--- a/CodeGen/post_generate.py
+++ b/CodeGen/post_generate.py
@@ -28,9 +28,15 @@ ue_third_party_lib_path = os.path.join(ue_third_party_path, 'lib')
 
 ros_include_path = os.path.join(ros_path, 'include')
 ros_lib_path = os.path.join(ros_path, 'lib')
+print(f'COPY {ros_package_name} FROM')
+print(ros_include_path)
+print(ros_lib_path)
 
 os.makedirs(ue_third_party_include_path, exist_ok=True)
 os.makedirs(ue_third_party_lib_path, exist_ok=True)
+print('TO')
+print(ue_third_party_include_path)
+print(ue_third_party_lib_path)
 
 # copy header
 try:
@@ -44,5 +50,5 @@ except OSError as e:
     exit(0)
 
 # copy lib
-for file_name in glob.glob(os.path.join(ros_path, 'lib', 'lib'+ros_package_name+'__*.so')):
+for file_name in glob.glob(os.path.join(ros_lib_path, 'lib'+ros_package_name+'__*.so')):
     shutil.copy(file_name, ue_third_party_lib_path)

--- a/CodeGen/templates/Action.h
+++ b/CodeGen/templates/Action.h
@@ -15,7 +15,7 @@
 #include "ROS2{{data.NameCap}}Action.generated.h"
 
 USTRUCT(Blueprintable)
-struct RCLUE_API F{{data.StructName}}_SendGoal_Request
+struct RCLUE_API F{{data.StructName}}SendGoalRequest
 {
 	GENERATED_BODY()
 
@@ -45,7 +45,7 @@ public:
 };
 
 USTRUCT(Blueprintable)
-struct RCLUE_API F{{data.StructName}}_SendGoal_Response
+struct RCLUE_API F{{data.StructName}}SendGoalResponse
 {
 	GENERATED_BODY()
 
@@ -70,7 +70,7 @@ public:
 };
 
 USTRUCT(Blueprintable)
-struct RCLUE_API F{{data.StructName}}_GetResult_Request
+struct RCLUE_API F{{data.StructName}}GetResultRequest
 {
 	GENERATED_BODY()
 
@@ -96,7 +96,7 @@ public:
 };
 
 USTRUCT(Blueprintable)
-struct RCLUE_API F{{data.StructName}}_GetResult_Response
+struct RCLUE_API F{{data.StructName}}GetResultResponse
 {
 	GENERATED_BODY()
 
@@ -118,7 +118,7 @@ public:
 };
 
 USTRUCT(Blueprintable)
-struct RCLUE_API F{{data.StructName}}_FeedbackMessage
+struct RCLUE_API F{{data.StructName}}FeedbackMessage
 {
 	GENERATED_BODY()
 
@@ -160,36 +160,36 @@ public:
 	virtual const rosidl_action_type_support_t* GetTypeSupport() const override;
 
   	UFUNCTION(BlueprintCallable)
-	void SetGoalRequest(const F{{data.StructName}}_SendGoal_Request& Goal);
+	void SetGoalRequest(const F{{data.StructName}}SendGoalRequest& Goal);
 
   	UFUNCTION(BlueprintCallable)
-	void GetGoalRequest(F{{data.StructName}}_SendGoal_Request& Goal) const;
+	void GetGoalRequest(F{{data.StructName}}SendGoalRequest& Goal) const;
 	
   	UFUNCTION(BlueprintCallable)
-	void SetGoalResponse(const F{{data.StructName}}_SendGoal_Response& Goal);
+	void SetGoalResponse(const F{{data.StructName}}SendGoalResponse& Goal);
 
   	UFUNCTION(BlueprintCallable)
-	void GetGoalResponse(F{{data.StructName}}_SendGoal_Response& Goal) const;
+	void GetGoalResponse(F{{data.StructName}}SendGoalResponse& Goal) const;
 	
   	UFUNCTION(BlueprintCallable)
-	void SetResultRequest(const F{{data.StructName}}_GetResult_Request& Result);
+	void SetResultRequest(const F{{data.StructName}}GetResultRequest& Result);
 
   	UFUNCTION(BlueprintCallable)
-	void GetResultRequest(F{{data.StructName}}_GetResult_Request& Result) const;
+	void GetResultRequest(F{{data.StructName}}GetResultRequest& Result) const;
 	
   	UFUNCTION(BlueprintCallable)
-	void SetResultResponse(const F{{data.StructName}}_GetResult_Response& Result);
+	void SetResultResponse(const F{{data.StructName}}GetResultResponse& Result);
 
   	UFUNCTION(BlueprintCallable)
-	void GetResultResponse(F{{data.StructName}}_GetResult_Response& Result) const;
+	void GetResultResponse(F{{data.StructName}}GetResultResponse& Result) const;
 
 
 
   	UFUNCTION(BlueprintCallable)
-	void SetFeedback(const F{{data.StructName}}_FeedbackMessage& Feedback);
+	void SetFeedback(const F{{data.StructName}}FeedbackMessage& Feedback);
 
   	UFUNCTION(BlueprintCallable)
-	void GetFeedback(F{{data.StructName}}_FeedbackMessage& Feedback) const;
+	void GetFeedback(F{{data.StructName}}FeedbackMessage& Feedback) const;
 	
 	virtual void* GetGoalRequest() override;
 	virtual void* GetGoalResponse() override;
@@ -198,9 +198,9 @@ public:
 	virtual void* GetFeedbackMessage() override;
 
 private:
-	{{data.Group}}__action__{{data.NameCap}}_SendGoal_Request {{data.NameCap}}_goal_request;
-	{{data.Group}}__action__{{data.NameCap}}_SendGoal_Response {{data.NameCap}}_goal_response;
-	{{data.Group}}__action__{{data.NameCap}}_GetResult_Request {{data.NameCap}}_result_request;
-	{{data.Group}}__action__{{data.NameCap}}_GetResult_Response {{data.NameCap}}_result_response;
-	{{data.Group}}__action__{{data.NameCap}}_FeedbackMessage {{data.NameCap}}_feedback_message;
+	{{data.Group}}__action__{{data.NameCap}}SendGoalRequest {{data.NameCap}}_goal_request;
+	{{data.Group}}__action__{{data.NameCap}}SendGoalResponse {{data.NameCap}}_goal_response;
+	{{data.Group}}__action__{{data.NameCap}}GetResultRequest {{data.NameCap}}_result_request;
+	{{data.Group}}__action__{{data.NameCap}}GetResultResponse {{data.NameCap}}_result_response;
+	{{data.Group}}__action__{{data.NameCap}}FeedbackMessage {{data.NameCap}}_feedback_message;
 };

--- a/CodeGen/templates/Srv.h
+++ b/CodeGen/templates/Srv.h
@@ -13,7 +13,7 @@
 
 // potential problem: if this struct is defined multiple times!
 USTRUCT(Blueprintable)
-struct RCLUE_API F{{data.StructName}}_Request
+struct RCLUE_API F{{data.StructName}}Request
 {
 	GENERATED_BODY()
 
@@ -32,7 +32,7 @@ public:
 };
 
 USTRUCT(Blueprintable)
-struct RCLUE_API F{{data.StructName}}_Response
+struct RCLUE_API F{{data.StructName}}Response
 {
 	GENERATED_BODY()
 
@@ -66,19 +66,19 @@ public:
 	
 	// used by client
   	UFUNCTION(BlueprintCallable)
-	void SetRequest(const F{{data.StructName}}_Request& Request);
+	void SetRequest(const F{{data.StructName}}Request& Request);
 	
 	// used by service
   	UFUNCTION(BlueprintCallable)
-	void GetRequest(F{{data.StructName}}_Request& Request) const;
+	void GetRequest(F{{data.StructName}}Request& Request) const;
 	
 	// used by service
   	UFUNCTION(BlueprintCallable)
-	void SetResponse(const F{{data.StructName}}_Response& Response);
+	void SetResponse(const F{{data.StructName}}Response& Response);
 	
 	// used by client
   	UFUNCTION(BlueprintCallable)
-	void GetResponse(F{{data.StructName}}_Response& Response) const;
+	void GetResponse(F{{data.StructName}}Response& Response) const;
 	
 	virtual void* GetRequest() override;
 	virtual void* GetResponse() override;


### PR DESCRIPTION
CodeGen/CodeGeneratorFromPath.py
* Remove all '_' in outputted UE struct type name
* Add `is_valid_group_name()` before assigning `types_cpp[group_name]` to `info[~Types, ~SetFromROS2, SetROS2]`
* `templates/Action.h, Msg.h, Srv.h` No underscore in UE struct name
* `get_var_names()` -> `get_ue_var_names`() returns a dict {(type, size):var_name}
* `convert_to_cpp_type()` -> `convert_to_ue_type()`: add TArray output
* Add `get_type_default_value_str()` to auto fill-in default value if possible