### PR TITLE
add support for copying goal id into result request

### DIFF
--- a/CodeGen/templates/Action.cpp
+++ b/CodeGen/templates/Action.cpp
@@ -62,6 +62,14 @@ void UROS2{{data.UEName}}Action::GetResultRequest(FROS{{data.UEName}}GRReq& Resu
     Result.SetFromROS2({{data.NameCap}}_result_request);
 }
 
+void UROS2{{data.UEName}}Action::SetGoalIdToResultRequest(FROS{{data.UEName}}GRReq& Result)
+{
+    for (int i = 0; i < 16; i++)
+    {
+        Result.GoalId[i] = {{data.NameCap}}_goal_request.goal_id.uuid[i];
+    }
+}
+
 void UROS2{{data.UEName}}Action::SetResultResponse(const FROS{{data.UEName}}GRRes& Result)
 {
     Result.SetROS2({{data.NameCap}}_result_response);

--- a/CodeGen/templates/Action.h
+++ b/CodeGen/templates/Action.h
@@ -31,7 +31,7 @@ struct {{data.ModuleAPI}} FROS{{data.UEName}}SGReq
 
 public:
 	{{data.GoalConstantsDec}}
-  	
+
 	TArray<uint8, TFixedAllocator<16>> GoalId;
 
 	{{data.GoalTypes}}
@@ -185,7 +185,7 @@ public:
 		{
 			out_ros_data.goal_id.uuid[i] = GoalId[i];
 		}
-		
+
     	{{data.FeedbackSetROS2}}
 	}
 };
@@ -194,7 +194,7 @@ UCLASS()
 class {{data.ModuleAPI}} UROS2{{data.UEName}}Action : public UROS2GenericAction
 {
 	GENERATED_BODY()
-	
+
 public:
 	virtual void Init() override;
 
@@ -207,19 +207,22 @@ public:
 
   	UFUNCTION(BlueprintCallable)
 	void GetGoalRequest(FROS{{data.UEName}}SGReq& Goal) const;
-	
+
   	UFUNCTION(BlueprintCallable)
 	void SetGoalResponse(const FROS{{data.UEName}}SGRes& Goal);
 
   	UFUNCTION(BlueprintCallable)
 	void GetGoalResponse(FROS{{data.UEName}}SGRes& Goal) const;
-	
+
   	UFUNCTION(BlueprintCallable)
 	void SetResultRequest(const FROS{{data.UEName}}GRReq& Result);
 
   	UFUNCTION(BlueprintCallable)
 	void GetResultRequest(FROS{{data.UEName}}GRReq& Result) const;
-	
+
+    UFUNCTION(BlueprintCallable)
+    void SetGoalIdToResultRequest(FROS{{data.UEName}}GRReq& Result);
+
   	UFUNCTION(BlueprintCallable)
 	void SetResultResponse(const FROS{{data.UEName}}GRRes& Result);
 
@@ -231,7 +234,7 @@ public:
 
   	UFUNCTION(BlueprintCallable)
 	void GetFeedback(FROS{{data.UEName}}FB& Feedback) const;
-	
+
   	UFUNCTION(BlueprintCallable)
 	void SetGoalIdToFeedback(FROS{{data.UEName}}FB& Feedback);
 


### PR DESCRIPTION
Adds a Blueprint-callable function to copy the action goal ID into the result request.
This ID is required to retrieve the result of an action.